### PR TITLE
Add .ignore

### DIFF
--- a/jarvis/__init__.py
+++ b/jarvis/__init__.py
@@ -11,4 +11,5 @@ from . import (
     websearch,
     autoban,
     images,
-    utils)
+    utils,
+    ignore)

--- a/jarvis/core.py
+++ b/jarvis/core.py
@@ -201,6 +201,11 @@ def dispatcher(inp):
     name is used, or returning a disambiguation prompt if multiple commands
     match the partial input.
     """
+    inst = db.Ignored.find_one(user=inp.whatever)
+    if inst:
+        # This user is being ignored.
+        return
+    
     funcs = collections.OrderedDict()
 
     command = _get_command_func(inp)

--- a/jarvis/core.py
+++ b/jarvis/core.py
@@ -201,7 +201,7 @@ def dispatcher(inp):
     name is used, or returning a disambiguation prompt if multiple commands
     match the partial input.
     """
-    inst = db.Ignored.find_one(user=inp.whatever)
+    inst = db.Ignored.find_one(user=inp.user)
     if inst:
         # This user is being ignored.
         return

--- a/jarvis/db.py
+++ b/jarvis/db.py
@@ -136,7 +136,7 @@ class ChannelConfig(BaseModel):
 class Ignored(BaseModel):
     """Database Ignored Users Table."""
 
-    user = peewee.CharField(index=True)
+    user = peewee.CharField(index=True, unique=True)
 
 
 ###############################################################################

--- a/jarvis/db.py
+++ b/jarvis/db.py
@@ -133,6 +133,12 @@ class ChannelConfig(BaseModel):
     gibber = peewee.BooleanField(null=True)
 
 
+class Ignored(BaseModel):
+    """Database Ignored Users Table."""
+
+    user = peewee.CharField(index=True)
+
+
 ###############################################################################
 
 
@@ -150,5 +156,5 @@ def init(path):
 
     db.connect()
     db.create_tables([
-        Tell, Message, Quote, Memo,
-        Subscriber, Restricted, Alert, ChannelConfig], safe=True)
+        Tell, Message, Quote, Memo, Subscriber,
+        Restricted, Alert, ChannelConfig, Ignored], safe=True)

--- a/jarvis/ignore.py
+++ b/jarvis/ignore.py
@@ -15,12 +15,13 @@ db.init('jarvis.db')
 ###############################################################################
 
 @core.command
+@core.require(channel=core.config.irc.sssc)
 @parser.ignore
 def ignore(inp, *, user):
     inst = db.Ignored.find_one(user=user)
     if inst:
         db.Ignored.purge(user=user)
-        return lex.ignore.unignored(user=user)
+        return lex.ignore.unignoring(user=user)
     else:
         db.Ignored.create(user=user)
-        return lex.ignore.ignored(user=user)
+        return lex.ignore.ignoring(user=user)

--- a/jarvis/ignore.py
+++ b/jarvis/ignore.py
@@ -17,6 +17,8 @@ db.init('jarvis.db')
 @core.command
 @parser.ignore
 def ignore(inp, *, user):
+    if not user:
+        return lex.ignore.no_user
     inst = db.Ignored.find_one(user=user)
     if inst:
         db.Ignored.purge(user=user)

--- a/jarvis/ignore.py
+++ b/jarvis/ignore.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+
+###############################################################################
+# Module Imports
+###############################################################################
+
+from . import core, lex, parser, db
+
+###############################################################################
+
+db.init('jarvis.db')
+
+###############################################################################
+# Commands
+###############################################################################
+
+@core.command
+@parser.ignore
+def ignore(inp, *, user):
+    inst = db.Ignored.find_one(user=user)
+    if inst:
+        db.Ignored.purge(user=user)
+        return lex.ignore.unignored(user=user)
+    else:
+        db.Ignored.create(user=user)
+        return lex.ignore.ignored(user=user)

--- a/jarvis/ignore.py
+++ b/jarvis/ignore.py
@@ -17,8 +17,6 @@ db.init('jarvis.db')
 @core.command
 @parser.ignore
 def ignore(inp, *, user):
-    if not user:
-        return lex.ignore.no_user
     inst = db.Ignored.find_one(user=user)
     if inst:
         db.Ignored.purge(user=user)

--- a/jarvis/lexicon.yaml
+++ b/jarvis/lexicon.yaml
@@ -243,6 +243,9 @@ gibber:
     say: "{{ text }}"
     no_such_user: Haven't seen them.
     small_sample: The sample is not large enough to construct a text model.
+ignore:
+    ignoring: I will now ignore anything said by {user}.
+    unignoring: No longer ignoring {user}.
 ###############################################################################
 # SCP
 ###############################################################################

--- a/jarvis/lexicon.yaml
+++ b/jarvis/lexicon.yaml
@@ -246,6 +246,7 @@ gibber:
 ignore:
     ignoring: I will now ignore anything said by {user}.
     unignoring: No longer ignoring {user}.
+    no_user: You must specific a user to ignore/unignore.
 ###############################################################################
 # SCP
 ###############################################################################

--- a/jarvis/parser.py
+++ b/jarvis/parser.py
@@ -1263,4 +1263,17 @@ def configure(pr):
             type=bool_string,
             help="""New value of the configured parameter.""")
 
+
+###############################################################################
+# Ignore
+###############################################################################
+
+
+@parser
+def ignore(pr):
+    pr.add_argument(
+        'user',
+        type=str.lower,
+        help="""IRC nick of the user to ignore/unignore.""")
+
     ###########################################################################

--- a/jarvis/resources/lexicon/static.yaml
+++ b/jarvis/resources/lexicon/static.yaml
@@ -72,6 +72,12 @@ gibber:
     self: Gibbing the bot is not allowed.
     model: Please wait while I construct the text model...
 ###############################################################################
+# Ignore
+###############################################################################
+ignore:
+    ignoring: I will now ignore anything said by {user}.
+    unignoring: No longer ignoring {user}.
+###############################################################################
 # SCP
 ###############################################################################
 unused:

--- a/jarvis/resources/lexicon/static.yaml
+++ b/jarvis/resources/lexicon/static.yaml
@@ -75,8 +75,8 @@ gibber:
 # Ignore
 ###############################################################################
 ignore:
-    ignoring: I will now ignore anything said by {user}.
-    unignoring: No longer ignoring {user}.
+    ignoring: I will now ignore anything said by {{ user }}.
+    unignoring: No longer ignoring {{ user }}.
 ###############################################################################
 # SCP
 ###############################################################################


### PR DESCRIPTION
By request (of myself!), here's a wee PR for .ignore, a command whose objective it is to prevent the bot from acknowledging the existence of certain users. I do not expect this to have any use for real people, only for bots who are good boys who won't change their name.

Here's what this PR changes:
* Create a new table, `Ignored`, that stores a unique list of ignored IRC nicks and nothing else
* Add a check to `dispatcher` in `core.py` that aborts the entire input process if the user's nick matches a name in the Ignored table
* Add a parser for the `.ignore` command that accepts only `user` as argument
* Add a couple of lines to `lexicon.yaml` to report ignoring/unignoring a user
* Add the command itself in a new file, `ignore.py`, as I didn't feel that it really fit in anywhere else.

I have not tested this, for reasons twofold:
1. I don't have the unencrypted config.yaml
2. I genuinely can't work out how to run the thing after installing it (my fault)

I suspect that .ignore may not play well with casing, as the `type` in `parser.ignore` is `str.lower` per several other of the parsers. Beyond that, I don't expect any other errors - but who ever does?

For what it's worth, your bot is far more receptive to foreign PRs than mine is.